### PR TITLE
Add gitRef and gitCommit support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
   force_package_download:
     default: 'false'
     description: 'Force download of installed packages.'
+  git_ref:
+    description: 'Git branch reference to the specific resources of a version controlled Octopus Project. This is required for version controlled projects.'
+  git_commit:
+    description: 'Git commit pointing to the specific resources of a version controlled Octopus Project. If empty, it will use the HEAD from the corresponding gitRef parameter.'
   guided_failure:
     default: 'false'
     description: 'Use Guided Failure mode.'

--- a/src/create-release.ts
+++ b/src/create-release.ts
@@ -41,6 +41,8 @@ function getArgs(parameters: InputParameters): string[] {
   if (parameters.ignoreSslErrors) args.push(`--ignoreSslErrors`)
   if (parameters.logLevel.length > 0 && parameters.logLevel !== `debug`)
     args.push(`--logLevel=${parameters.logLevel}`)
+  if (parameters.gitRef.length > 0) args.push(`--gitRef=${parameters.gitRef}`)
+  if (parameters.gitCommit.length > 0) args.push(`--gitCommit=${parameters.project}`)
   if (parameters.noDeployAfter.length > 0)
     args.push(`--noDeployAfter=${parameters.noDeployAfter}`)
   if (parameters.noRawLog) args.push(`--noRawLog`)

--- a/src/input-parameters.ts
+++ b/src/input-parameters.ts
@@ -14,6 +14,8 @@ export interface InputParameters {
   excludeMachines: string
   force: boolean
   forcePackageDownload: boolean
+  gitRef: string
+  gitCommit: string
   guidedFailure: string
   ignoreChannelRules: boolean
   ignoreExisting: boolean
@@ -63,6 +65,8 @@ export function get(): InputParameters {
     excludeMachines: getInput('exclude_machines'),
     force: getBooleanInput('force'),
     forcePackageDownload: getBooleanInput('force_package_download'),
+    gitRef: getInput('git_ref'),
+    gitCommit: getInput('git_commit'),
     guidedFailure: getInput('guided_failure'),
     ignoreChannelRules: getBooleanInput('ignore_channel_rules'),
     ignoreExisting: getBooleanInput('ignore_existing'),


### PR DESCRIPTION
Latest version of octo.cli supports passing two new parameters `--gitRef` and `--gitCommit` for version controlled projects.