### PR TITLE
Adds renovate for dependency management

### DIFF
--- a/.github/workflows/renovate-pull-request-automation.yml
+++ b/.github/workflows/renovate-pull-request-automation.yml
@@ -1,0 +1,26 @@
+name: Renovate Pull Request Approval
+
+on:
+  pull_request:
+    branches: [main]
+
+# Increase the access for the GITHUB_TOKEN
+permissions:
+  # This Allows the GITHUB_TOKEN to approve pull requests
+  pull-requests: write
+  # This Allows the GITHUB_TOKEN to auto merge pull requests
+  contents: write
+
+env:
+  PR_URL: ${{github.event.pull_request.html_url}}
+  # By default, GitHub Actions workflows triggered by renovate get a GITHUB_TOKEN with read-only permissions.
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+jobs:
+  approve_renovate_pull_requests:
+    runs-on: ubuntu-latest
+    name: Approve renovate pull request
+    if: ${{ (github.actor == 'Octobob') && (contains(github.head_ref, 'renovate')) }}
+    steps:
+      - name: Approve a renovate created PR
+        run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,28 @@
+name: Renovate
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        type: boolean
+        required: false
+        default: false
+        description: Dry run (don't create PRs)
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@0dbf03d3f50da30b8e523f51b628d2743c4934dc # v39.0.6
+        with:
+          configurationFile: renovate-config.js
+          token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun && 'full' || null }}

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -1,0 +1,33 @@
+// eslint-disable-next-line import/no-commonjs
+module.exports = {
+  extends: [
+    'config:base',
+    ':disableMajorUpdates',
+    ':ignoreModulesAndTests',
+    ':pinVersions',
+    ':rebaseStalePrs',
+    ':automergeDigest',
+    ':automergePatch',
+    ':automergePr',
+    ':automergeRequireAllStatusChecks',
+    ':automergeLinters',
+    ':automergeTesters',
+    ':automergeTypes',
+    'packages:eslint',
+    'workarounds:typesNodeVersioning',
+    'github>whitesource/merge-confidence:beta'
+  ],
+  branchPrefix: 'renovate/',
+  platform: 'github',
+  repositories: ['OctopusDeploy/create-release-action'],
+  packageRules: [],
+  timezone: 'Australia/Brisbane',
+  onboarding: false,
+  requireConfig: false,
+  allowedPostUpgradeCommands: ['.*'],
+  postUpgradeTasks: {
+    commands: ['npm install && npm run build'],
+    fileFilters: ['**/index.js'],
+    executionMode: 'update'
+  }
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -3,5 +3,9 @@
     "include": [
       "src",
       "__tests__",
-    ]
+      "renovate-config.js"
+    ],
+    "compilerOptions": {
+      "allowJs": true
+    }
   }


### PR DESCRIPTION
This PR adds automated dependency management using [Renovate](https://github.com/renovatebot/renovate). Renovate will run on a nightly basis to create PRs to update dependencies. Patch/digest changes will be automatically merged.

The config was taken from https://github.com/OctopusDeploy/login and adapted.

Fixes #388.