### PR TITLE
Add slack notification for scheduled build failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,3 +81,19 @@ jobs:
 
       - name: Echo package number from self-test
         run: echo "Release Created [${{ steps.self_test.outputs.release_number }}]"
+
+  notify: 
+    runs-on: ubuntu-latest
+    name: Slack - Notify on nightly build failure
+    needs: [test]
+    if: ${{ github.event_name == 'schedule' && failure() }}
+
+    steps:
+      - name: Notify
+        uses: zuplo/github-action-slack-notify-build@v2
+        with:
+          channel_id: ${{ secrets.SLACK_NOTIFICATIONS_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}


### PR DESCRIPTION
Currently if there are scheduled build failures then some team members seem to get emails, but others don't. This might be due to filters, or perhaps it's whoever last did a commit to the repo? Either way it's not ideal, so this PR adds a step to the build which will send a notification to the team in slack.