### PR TITLE
chore: Enable shell executor for post-upgrade commands in renovate

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -25,6 +25,7 @@ module.exports = {
   onboarding: false,
   requireConfig: false,
   allowedPostUpgradeCommands: ['.*'],
+  allowShellExecutorForPostUpgradeCommands: true,
   postUpgradeTasks: {
     commands: ['npm install && npm run build'],
     fileFilters: ['**/index.js'],


### PR DESCRIPTION
Renovate v43 changed the default behaviour for post upgrade commands which broke our renovate workflows. This re-enables the renovate v42 behaviour that runs post upgrade commands.

See _postUpgradeTasks will no longer run with shell mode by default https://github.com/renovatebot/renovate/pull/40230_ in the [43.0.0 release notes](https://github.com/renovatebot/renovate/releases/tag/43.0.0) for details.

[sc-134878]