### PR TITLE
fix: Update path to config file in Renovate workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@f9c81dddc9b589e4e6ae0326d1e36f6bc415d230 # v39.2.4
         with:
-          configurationFile: renovate-config.js
+          configurationFile: renovate-config.cjs
           token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
         env:
           LOG_LEVEL: debug


### PR DESCRIPTION
## What's this? 🌵 

The Renovate (update-dependencies) workflow has been failing since we renamed the renovate config file [as part of updating @actions/core](https://github.com/OctopusDeploy/create-release-action/pull/652/changes#r2978687431). This PR just updates the path to the config file in the workflow. 

[Here's a dry run of the updated action](https://github.com/OctopusDeploy/create-release-action/actions/runs/23773496688) to show that it's working ✅ 

Fixes DEVEX-184