### PR TITLE
chore: Update version of dorny/test-reporter to supprot node 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm run all
 
       - name: Test Report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v3
         if: success() || failure()
         with:
           name: JEST Tests


### PR DESCRIPTION
Our version for dorny/test-reporter is well behind the current release. Version 3 supports the node24 action infra.

This is cannary, to see what would be involved for updating all instances

<img width="2560" height="1271" alt="image" src="https://github.com/user-attachments/assets/ed03af84-4d04-41f8-b605-781848e11736" />

