### PR TITLE
fix(deps): update js-yaml to resolve DoS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "jest": "29.7.0",
         "jest-circus": "29.7.0",
         "jest-junit": "15.0.0",
-        "js-yaml": "4.3.0",
+        "js-yaml": "5.2.1",
         "prettier": "3.8.3",
         "ts-jest": "29.4.9",
         "typescript": "5.9.3"
@@ -1158,6 +1158,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@eslint/js": {
       "version": "9.39.4",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
@@ -1296,9 +1319,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6093,9 +6116,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "dev": true,
       "funding": [
         {
@@ -6112,7 +6135,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsesc": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jest": "29.7.0",
     "jest-circus": "29.7.0",
     "jest-junit": "15.0.0",
-    "js-yaml": "4.3.0",
+    "js-yaml": "5.2.1",
     "prettier": "3.8.3",
     "ts-jest": "29.4.9",
     "typescript": "5.9.3"


### PR DESCRIPTION
## What
Resolves the js-yaml security advisory (quadratic-complexity DoS in YAML merge-key handling — GHSA-52cp-r559-cp3m / GHSA-h67p-54hq-rp68).

- **Direct devDependency** → `5.2.1` (latest)
- **Transitive under `@istanbuljs/load-nyc-config`** (jest coverage) → `3.15.0` — this consumer requires the 3.x line, so 3.15.0 is the applicable patch
- Nested copy under eslint tooling resolves to `4.3.0` (also patched)

## Notes
- `js-yaml` is a **devDependency only**, not imported by source, so it's not bundled into `dist` — `dist` is unchanged.
- Changes limited to `package.json` + `package-lock.json`.
- `npm audit` reports js-yaml clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)