### PR TITLE
fix(deps): bump @octopusdeploy/api-client to 3.11.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "3.0.0",
-        "@octopusdeploy/api-client": "3.11.5",
-        "axios": "^1.18.1",
+        "@octopusdeploy/api-client": "3.11.6",
         "tmp": "0.2.7"
       },
       "devDependencies": {
@@ -1759,13 +1758,13 @@
       }
     },
     "node_modules/@octopusdeploy/api-client": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.11.5.tgz",
-      "integrity": "sha512-VSGQv4sy7CQlK+PaMkNu5+WF/xeftBReTUBoGOddcEiq1qkXJhoN7uo5ZhUY87LwiNlh1ysBSottSV016wEW/A==",
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.11.6.tgz",
+      "integrity": "sha512-dshAoXSOsFSr3L0oOx08L/KQaAb7fQQKHnzx7uIfaOIKHN1oxnyAPqBmEiH3zJFIXJaL5icugNmLFyjKPkTYrw==",
       "license": "Apache-2.0",
       "dependencies": {
         "adm-zip": "^0.6.0",
-        "axios": "^1.15.2",
+        "axios": "^1.18.1",
         "form-data": "^4.0.4",
         "glob": "^8.0.3",
         "lodash": "^4.18.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   },
   "dependencies": {
     "@actions/core": "3.0.0",
-    "@octopusdeploy/api-client": "3.11.5",
-    "axios": "^1.18.1",
+    "@octopusdeploy/api-client": "3.11.6",
     "tmp": "0.2.7"
   },
   "description": "GitHub Action to Create a Release in Octopus Deploy",


### PR DESCRIPTION
## What
Bumps `@octopusdeploy/api-client` to **3.11.6**.

The api-client now manages `axios` (bumped to **1.18.1** upstream). Where this action carried its own direct `axios` dependency but does **not** import axios in source, that redundant dependency has been **removed** — axios continues to resolve transitively via the api-client.

## Changes
- `package.json` — api-client → 3.11.6 (and direct `axios` removed where applicable)
- `package-lock.json` — updated
- `dist/index.js` — rebuilt where the bundled output actually changed (unchanged for actions that already bundled axios 1.18.1)

Branch cut from latest `main`. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)